### PR TITLE
 Prevent naming collisions with methods implemented by Apple, which was causing a crash with Intercom

### DIFF
--- a/Code/CoreData/NSManagedObject+ActiveRecord.h
+++ b/Code/CoreData/NSManagedObject+ActiveRecord.h
@@ -31,12 +31,12 @@
  * The NSEntityDescription for the Subclass
  * defaults to the subclass className, may be overridden
  */
-+ (NSEntityDescription*)entity;
++ (NSEntityDescription*)MR_entity;
 
 /**
  * Returns an initialized NSFetchRequest for the entity, with no predicate
  */
-+ (NSFetchRequest*)fetchRequest;
++ (NSFetchRequest*)MR_fetchRequest;
 
 /**
  * Fetches all objects from the persistent store identified by the fetchRequest

--- a/Code/CoreData/NSManagedObject+ActiveRecord.m
+++ b/Code/CoreData/NSManagedObject+ActiveRecord.m
@@ -51,14 +51,14 @@ RK_FIX_CATEGORY_BUG(NSManagedObject_ActiveRecord)
 
 #pragma mark - RKManagedObject methods
 
-+ (NSEntityDescription*)entity {
++ (NSEntityDescription*)MR_entity {
     NSString* className = [NSString stringWithCString:class_getName([self class]) encoding:NSASCIIStringEncoding];
     return [NSEntityDescription entityForName:className inManagedObjectContext:[NSManagedObjectContext contextForCurrentThread]];
 }
 
-+ (NSFetchRequest*)fetchRequest {
++ (NSFetchRequest*)MR_fetchRequest {
     NSFetchRequest *fetchRequest = [[[NSFetchRequest alloc] init] autorelease];
-    NSEntityDescription *entity = [self entity];
+    NSEntityDescription *entity = [self MR_entity];
     [fetchRequest setEntity:entity];
     return fetchRequest;
 }
@@ -128,7 +128,7 @@ RK_FIX_CATEGORY_BUG(NSManagedObject_ActiveRecord)
 }
 
 + (id)object {
-    id object = [[self alloc] initWithEntity:[self entity] insertIntoManagedObjectContext:[NSManagedObjectContext contextForCurrentThread]];
+    id object = [[self alloc] initWithEntity:[self MR_entity] insertIntoManagedObjectContext:[NSManagedObjectContext contextForCurrentThread]];
     return [object autorelease];
 }
 

--- a/Code/CoreData/NSManagedObject+ActiveRecord.m
+++ b/Code/CoreData/NSManagedObject+ActiveRecord.m
@@ -102,13 +102,13 @@ RK_FIX_CATEGORY_BUG(NSManagedObject_ActiveRecord)
 }
 
 + (NSArray*)objectsWithPredicate:(NSPredicate*)predicate {
-    NSFetchRequest* fetchRequest = [self fetchRequest];
+    NSFetchRequest* fetchRequest = [self MR_fetchRequest];
     [fetchRequest setPredicate:predicate];
     return [self objectsWithFetchRequest:fetchRequest];
 }
 
 + (id)objectWithPredicate:(NSPredicate*)predicate {
-    NSFetchRequest* fetchRequest = [self fetchRequest];
+    NSFetchRequest* fetchRequest = [self MR_fetchRequest];
     [fetchRequest setPredicate:predicate];
     return [self objectWithFetchRequest:fetchRequest];
 }
@@ -118,7 +118,7 @@ RK_FIX_CATEGORY_BUG(NSManagedObject_ActiveRecord)
 }
 
 + (NSUInteger)count:(NSError**)error {
-    NSFetchRequest* fetchRequest = [self fetchRequest];
+    NSFetchRequest* fetchRequest = [self MR_fetchRequest];
     return [[NSManagedObjectContext contextForCurrentThread] countForFetchRequest:fetchRequest error:error];
 }
 


### PR DESCRIPTION
Prevent naming collisions with methods implemented by Apple.
Prefix a couple of methods with MR_ as seen in later versions of MagicalRecord.
Since iOS 10, Apple has implemented these methods and their code can end up using
the MagicalRecord implementations which can cause crashes because of the way they
have implemented or prevented use of class_getName for their private classes.
Prefixing prevents naming collisions, and MagicalRecord code now uses these
prefixed methods.
MOB-5919

