### PR TITLE
Fix RKRequest to use the correct Bearer prefix to the auth headers

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -374,7 +374,7 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
 
     // OAuth 2 valid request
     if(self.authenticationType == RKRequestAuthenticationTypeOAuth2) {
-        NSString *authorizationString = [NSString stringWithFormat:@"OAuth2 %@",self.OAuth2AccessToken];
+        NSString *authorizationString = [NSString stringWithFormat:@"Bearer %@",self.OAuth2AccessToken];
         [_URLRequest setValue:authorizationString forHTTPHeaderField:@"Authorization"];
     }
 


### PR DESCRIPTION
Fix RKRequest to use the correct Bearer prefix to the auth headers

MOB-6209