### PR TITLE
Skip nil objects in entity cache load to prevent NSInternalInconsistencyException crash

### DIFF
--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -118,8 +118,11 @@
     for (NSManagedObjectID *objectID in objectIDs) {
         NSError *error = nil;
         NSManagedObject *object = [self.managedObjectContext existingObjectWithID:objectID error:&error];
-        if (! object && error) {
-            RKLogError(@"Failed to retrieve managed object with ID %@: %@", objectID, error);
+        if (! object) {
+            if (error) {
+                RKLogError(@"Failed to retrieve managed object with ID %@: %@", objectID, error);
+            }
+            continue;
         }
 
         [self addObject:object];


### PR DESCRIPTION
When existingObjectWithID: returns nil (e.g. object deleted by concurrent sync operation), the nil was passed to addObject: which triggers an NSAssert on entity equality. Now we skip nil objects with a continue.

Related firebase crash: https://console.firebase.google.com/project/agworld-mobile-mini/crashlytics/app/ios:com.agworld.mobilemini/issues/8fbc3a2c641b072ddbd46c7b05ffb8c6